### PR TITLE
NoTicket: Use self-hosted runners instead of GitHub-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:  
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:  
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
This pull request is to change the CI runner from GitHub-hosted runners (ubuntu-latest) to self-hosted runners. This change is necessary to improve the cost and control over our build environment. Please review our changes and provide your feedback.
