### PR TITLE
fix: missing vue special method

### DIFF
--- a/src/__tests__/vue-class-component/migrator-methods.test.ts
+++ b/src/__tests__/vue-class-component/migrator-methods.test.ts
@@ -13,6 +13,9 @@ describe('Methods Property Migration', () => {
                     created() {
                         console.log("OK");
                     }
+                    beforeDestroy() {
+                        console.log("beforeDestroy triggerd");
+                    }
                 }`,
         // Results
         `import { defineComponent } from "vue";
@@ -20,6 +23,9 @@ describe('Methods Property Migration', () => {
                 export default defineComponent({
                     created() {
                         console.log("OK");
+                    },
+                    beforeDestroy() {
+                        console.log("beforeDestroy triggerd");
                     }
                 })`,
       );

--- a/src/migrator/config.ts
+++ b/src/migrator/config.ts
@@ -16,6 +16,7 @@ export const vueSpecialMethods = [
   'activated',
   'deactivated',
   'serverPrefetch',
+  'beforeDestroy',
   'destroyed',
 ]; // Vue methods that won't be included under methods: {...}, they go to the root.
 


### PR DESCRIPTION
First, thanks for this project for helping old projects' migration ♥️.
I got a bug while using this project to migrate my project because there has some code like below:

```js
@Component
export default class Test extends Vue {
    created() {
        document.addEventListener('mousedown', onMousedown);
    }
    onMousedown() {
        console.log('mousedown');
    }
    beforeDestroy() {
        document.removeEventListener('mousedown', onMousedown);
    }
}
```

this code was migrated into below:

```js
import { defineComponent } from "vue";

export default defineComponent({
    created() {
        document.addEventListener('mousedown', onMousedown);
    },
    methods() {
        onMousedown() {
            console.log('mousedown');
        },
        beforeDestroy() {
            document.removeEventListener('mousedown', onMousedown);
        }
    }
})
```

This will miss the event unregister after the component destroyed because the special method "beforeDestroy" was incorrectly migrated into methods. It cause unexpected event handles in my project.

So I create this PR to fix this bug about "beforeDestroy" using.