### PR TITLE
Feat/parse only single file

### DIFF
--- a/src/__tests__/migrator.test.ts
+++ b/src/__tests__/migrator.test.ts
@@ -1,5 +1,7 @@
+import { Project } from 'ts-morph';
 import { project, createSourceFile } from './utils';
-import { migrateFile } from '../migrator';
+import { migrateFile, migrateSingleFile } from '../migrator';
+import * as migrator from '../migrator/migrator';
 
 describe('migrateFile()', () => {
   afterAll(() => {
@@ -88,6 +90,68 @@ describe('migrateFile()', () => {
           'import Vue, { mounted, defineComponent } from "vue";',
           'export default defineComponent({})',
         ].join('\n'));
+    });
+
+    test('Vue import respected in .vue file', async () => {
+      const sourceFile = createSourceFile([
+        '<script lang="ts">',
+        'import Vue, { mounted } from "vue";',
+        '@Component',
+        'export default class {}',
+        '</script>',
+      ].join('\n'), 'vue');
+
+      const migratedFile = await migrateFile(project, sourceFile);
+      expect(migratedFile.getText())
+        .toBe([
+          '<script lang="ts">',
+          'import Vue, { mounted, defineComponent } from "vue";',
+          'export default defineComponent({})',
+          '</script>',
+        ].join('\n'));
+    });
+  });
+});
+
+describe('migrateSingleFile()', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when a file path is neither .vue nor .ts file', () => {
+    let migrateFileSpy: jest.SpyInstance;
+    beforeEach(() => {
+      migrateFileSpy = jest.spyOn(migrator, 'migrateFile');
+    });
+
+    test('should not call `migrateFile`', async () => {
+      await migrateSingleFile('test.txt', false);
+
+      expect(migrateFileSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when a file path is a .vue file', () => {
+    let migrateFileSpy: jest.SpyInstance;
+    const scriptSource = `'<script lang="ts">',
+'import Vue, { mounted } from "vue";',
+'@Component',
+'export default class {}',
+'</script>',
+`;
+    const sourceFile = createSourceFile(scriptSource, 'vue');
+
+    beforeEach(() => {
+      migrateFileSpy = jest.spyOn(migrator, 'migrateFile');
+      process.cwd = jest.fn(() => '/');
+      Project.prototype.addSourceFileAtPath = jest.fn(() => sourceFile);
+      Project.prototype.getSourceFiles = jest.fn(() => [sourceFile]);
+    });
+
+    test('should call `migrateFile`', async () => {
+      await migrateSingleFile(sourceFile.getFilePath(), false);
+
+      expect(migrateFileSpy).toHaveBeenCalledWith(expect.anything(), sourceFile);
     });
   });
 });

--- a/src/__tests__/migrator.test.ts
+++ b/src/__tests__/migrator.test.ts
@@ -1,4 +1,4 @@
-import { Project } from 'ts-morph';
+import { Project, SourceFile } from 'ts-morph';
 import { project, createSourceFile } from './utils';
 import { migrateFile, migrateSingleFile } from '../migrator';
 import * as migrator from '../migrator/migrator';
@@ -107,6 +107,7 @@ describe('migrateFile()', () => {
           '<script lang="ts">',
           'import Vue, { mounted, defineComponent } from "vue";',
           'export default defineComponent({})',
+          '',
           '</script>',
         ].join('\n'));
     });
@@ -139,11 +140,12 @@ describe('migrateSingleFile()', () => {
 'export default class {}',
 '</script>',
 `;
-    const sourceFile = createSourceFile(scriptSource, 'vue');
+    let sourceFile: SourceFile;
 
     beforeEach(() => {
       migrateFileSpy = jest.spyOn(migrator, 'migrateFile');
       process.cwd = jest.fn(() => '/');
+      sourceFile = createSourceFile(scriptSource, 'vue');
       Project.prototype.addSourceFileAtPath = jest.fn(() => sourceFile);
       Project.prototype.getSourceFiles = jest.fn(() => [sourceFile]);
     });

--- a/src/__tests__/option.test.ts
+++ b/src/__tests__/option.test.ts
@@ -1,0 +1,29 @@
+import { OptionParser } from '../migrator/option';
+
+describe('OptionParser', () => {
+  describe('when options are not provided', () => {
+    it('should throw an error', () => {
+      expect(() => new OptionParser({}).parse()).toThrowError('Either directory or file should be provided. Not both or none');
+    });
+  });
+
+  describe('when both directory and file are provided', () => {
+    it('should throw an error', () => {
+      expect(() => new OptionParser({ directory: 'dir', file: 'file' }).parse()).toThrowError('Either directory or file should be provided. Not both or none');
+    });
+  });
+
+  describe('when directory is provided', () => {
+    it('should return directory mode option', () => {
+      const options = new OptionParser({ directory: '/home/auto-test', sfc: true }).parse();
+      expect(options).toStrictEqual({ directory: '/home/auto-test', sfc: true });
+    });
+  });
+
+  describe('when file is provided', () => {
+    it('should return file mode option', () => {
+      const options = new OptionParser({ file: '/home/auto-test/InputNumber.vue', sfc: false }).parse();
+      expect(options).toStrictEqual({ file: '/home/auto-test/InputNumber.vue', sfc: false });
+    });
+  });
+});

--- a/src/migrator-cli.ts
+++ b/src/migrator-cli.ts
@@ -3,7 +3,7 @@ import { migrate } from './migrator';
 
 const program = new Command()
   .option('-d, --directory <string>', 'Directory to migrate. Either directory or file should be provided, not both or none.')
-  .option('-f, --file <string>', 'Directory to migrate, Either directory or file should be provided, not both or none.')
+  .option('-f, --file <string>', 'File to migrate, Either directory or file should be provided, not both or none.')
   .option(
     '-s, --sfc',
     'If you would like to generate a SFC and remove the original scss and ts files',

--- a/src/migrator-cli.ts
+++ b/src/migrator-cli.ts
@@ -1,14 +1,15 @@
 import { Command } from 'commander';
-import { migrateDirectory } from './migrator';
+import { migrate } from './migrator';
 
 const program = new Command()
-  .requiredOption('-d, --directory <string>', 'Directory to migrate')
+  .option('-d, --directory <string>', 'Directory to migrate. Either directory or file should be provided, not both or none.')
+  .option('-f, --file <string>', 'Directory to migrate, Either directory or file should be provided, not both or none.')
   .option(
     '-s, --sfc',
     'If you would like to generate a SFC and remove the original scss and ts files',
     false,
   )
-  .action((options) => migrateDirectory(options.directory, options.sfc))
+  .action((options) => migrate(options))
   .parse(process.argv);
 
 export default program;

--- a/src/migrator/index.ts
+++ b/src/migrator/index.ts
@@ -2,5 +2,5 @@ export {
   migrateDirectory,
   migrateFile,
   migrate,
-  migrateSingeFile,
+  migrateSingleFile,
 } from './migrator';

--- a/src/migrator/index.ts
+++ b/src/migrator/index.ts
@@ -1,4 +1,6 @@
 export {
   migrateDirectory,
   migrateFile,
+  migrate,
+  migrateSingeFile,
 } from './migrator';

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -132,7 +132,7 @@ export const migrateDirectory = async (directoryPath: string, toSFC: boolean) =>
   }
 };
 
-export const migrateSingeFile = async (filePath: string, toSFC: boolean): Promise<void> => {
+export const migrateSingleFile = async (filePath: string, toSFC: boolean): Promise<void> => {
   const fileExtensionPattern = /.+\.(vue|ts)$/;
   if (!fileExtensionPattern.test(filePath)) {
     logger.info(`${filePath} can not migrate. Only .vue files are supported.`);
@@ -141,12 +141,10 @@ export const migrateSingeFile = async (filePath: string, toSFC: boolean): Promis
 
   const fileToMigrate = path.join(process.cwd(), filePath);
   const project = new Project({});
-  project.addSourceFilesAtPaths(fileToMigrate);
+  project.addSourceFileAtPath(fileToMigrate);
   const sourceFiles = project.getSourceFiles();
 
-  logger.info(
-    `Migrating file: ${fileToMigrate}`,
-  );
+  logger.info(`Migrating file: ${fileToMigrate}`);
 
   const migrationPromises = migrateEachFile(sourceFiles, project);
   try {
@@ -171,7 +169,7 @@ export const migrate = async (option: any): Promise<void> => {
   const result = new OptionParser(option).parse();
   if (Object.keys(result).includes('file')) {
     const fileModeOption = result as FileModeOption;
-    migrateSingeFile(fileModeOption.file, (fileModeOption.sfc ?? false));
+    migrateSingleFile(fileModeOption.file, (fileModeOption.sfc ?? false));
   } else {
     const directoryModeOption = result as DirectoryModeOption;
     migrateDirectory(directoryModeOption.directory, (directoryModeOption.sfc ?? false));

--- a/src/migrator/option.ts
+++ b/src/migrator/option.ts
@@ -1,0 +1,43 @@
+export type CliOptions = {
+  directory?: string;
+  file?: string;
+  sfc?: boolean;
+};
+
+export type DirectoryModeOption = {
+  directory: string;
+  sfc?: boolean;
+};
+
+export type FileModeOption = {
+  file: string;
+  sfc?: boolean;
+};
+
+export type OptionMode = DirectoryModeOption | FileModeOption;
+
+export function canBeCliOptions(obj: any): obj is CliOptions {
+  return obj && typeof obj === 'object' && (obj.directory || obj.file || obj.sfc);
+}
+
+export class OptionParser {
+  constructor(private options: CliOptions) {
+    if ((!options.directory && !options.file) || (options.directory && options.file)) {
+      throw new Error('Either directory or file should be provided. Not both or none');
+    }
+  }
+
+  parse(): OptionMode {
+    if (this.options.directory) {
+      return {
+        directory: this.options.directory,
+        sfc: this.options.sfc,
+      };
+    }
+
+    return {
+      file: this.options.file,
+      sfc: this.options.sfc,
+    } as FileModeOption;
+  }
+}


### PR DESCRIPTION
# Overview

This is a feature request. 

Our project appreciates this awesome project, because its has so many class style components.
By the way, we want to migrate `.vue` file one by one checking passing unit tests.

So, this feature request proposes that `vue-class-migrator` can parse CLI option `-f` same as `-d`.

## Design

vue-class-migrator...

- can parse an option of single file migration
  - Add `migrate function` of entry point
- can parse -d option same as before
  - partially generalized migration promise
- force select either -f or -d
  - Add `OptionParser` class to force option selection

## Checks

I checked that...

- [ ] `-f` option works
- [ ] adding unit tests and existing tests does not break

