### PR TITLE
feat: Adjust methods order in components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
-name: CI
+name: auto-test
 
 on:
-  [push, pull_request]
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/__tests__/migrator.test.ts
+++ b/src/__tests__/migrator.test.ts
@@ -42,7 +42,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
           'export const Test = defineComponent({})',
         ].join('\n'));
     });
@@ -56,7 +56,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
           'export default defineComponent({})',
         ].join('\n'));
     });
@@ -72,14 +72,14 @@ describe('migrateFile()', () => {
       expect(migratedFile.getText())
         .toBe([
           'import Bla, { Blo } from "./blabla"',
-          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
           'export default defineComponent({})',
         ].join('\n'));
     });
 
     test('Vue import respected', async () => {
       const sourceFile = createSourceFile([
-        'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
+        'import Vue, { mounted } from \'~/lib/helper/fallback-composition-api\';',
         '@Component',
         'export default class Test {}',
       ].join('\n'));
@@ -87,7 +87,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import Vue, { mounted, defineComponent } from "~/lib/helper/fallback-composition-api";',
+          'import Vue, { mounted, defineComponent } from \'~/lib/helper/fallback-composition-api\';',
           'export default defineComponent({})',
         ].join('\n'));
     });
@@ -95,7 +95,7 @@ describe('migrateFile()', () => {
     test('Vue import respected in .vue file', async () => {
       const sourceFile = createSourceFile([
         '<script lang="ts">',
-        'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
+        'import Vue, { mounted } from \'~/lib/helper/fallback-composition-api\';',
         '@Component',
         'export default class {}',
         '</script>',
@@ -105,10 +105,36 @@ describe('migrateFile()', () => {
       expect(migratedFile.getText())
         .toBe([
           '<script lang="ts">',
-          'import Vue, { mounted, defineComponent } from "~/lib/helper/fallback-composition-api";',
+          'import Vue, { mounted, defineComponent } from \'~/lib/helper/fallback-composition-api\';',
           'export default defineComponent({})',
           '',
           '</script>',
+        ].join('\n'));
+    });
+  });
+
+  describe('Code styles', () => {
+    test('Single quotation and 2 spaces indentation', async () => {
+      const sourceFile = createSourceFile([
+        '@Component',
+        'export default class {',
+        '  myMethod() {',
+        '    return \'\';',
+        '  }',
+        '}',
+      ].join('\n'));
+
+      const migratedFile = await migrateFile(project, sourceFile);
+      expect(migratedFile.getText())
+        .toBe([
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
+          'export default defineComponent({',
+          '  methods: {',
+          '    myMethod() {',
+          '      return \'\';',
+          '    }',
+          '  }',
+          '})',
         ].join('\n'));
     });
   });
@@ -135,7 +161,7 @@ describe('migrateSingleFile()', () => {
   describe('when a file path is a .vue file', () => {
     let migrateFileSpy: jest.SpyInstance;
     const scriptSource = `'<script lang="ts">',
-'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
+'import Vue, { mounted } from '~/lib/helper/fallback-composition-api';',
 '@Component',
 'export default class {}',
 '</script>',

--- a/src/__tests__/migrator.test.ts
+++ b/src/__tests__/migrator.test.ts
@@ -42,7 +42,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import { defineComponent } from "vue";\n',
+          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
           'export const Test = defineComponent({})',
         ].join('\n'));
     });
@@ -56,7 +56,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import { defineComponent } from "vue";\n',
+          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
           'export default defineComponent({})',
         ].join('\n'));
     });
@@ -72,14 +72,14 @@ describe('migrateFile()', () => {
       expect(migratedFile.getText())
         .toBe([
           'import Bla, { Blo } from "./blabla"',
-          'import { defineComponent } from "vue";\n',
+          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
           'export default defineComponent({})',
         ].join('\n'));
     });
 
     test('Vue import respected', async () => {
       const sourceFile = createSourceFile([
-        'import Vue, { mounted } from "vue";',
+        'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
         '@Component',
         'export default class Test {}',
       ].join('\n'));
@@ -87,7 +87,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import Vue, { mounted, defineComponent } from "vue";',
+          'import Vue, { mounted, defineComponent } from "~/lib/helper/fallback-composition-api";',
           'export default defineComponent({})',
         ].join('\n'));
     });
@@ -95,7 +95,7 @@ describe('migrateFile()', () => {
     test('Vue import respected in .vue file', async () => {
       const sourceFile = createSourceFile([
         '<script lang="ts">',
-        'import Vue, { mounted } from "vue";',
+        'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
         '@Component',
         'export default class {}',
         '</script>',
@@ -105,7 +105,7 @@ describe('migrateFile()', () => {
       expect(migratedFile.getText())
         .toBe([
           '<script lang="ts">',
-          'import Vue, { mounted, defineComponent } from "vue";',
+          'import Vue, { mounted, defineComponent } from "~/lib/helper/fallback-composition-api";',
           'export default defineComponent({})',
           '',
           '</script>',
@@ -135,7 +135,7 @@ describe('migrateSingleFile()', () => {
   describe('when a file path is a .vue file', () => {
     let migrateFileSpy: jest.SpyInstance;
     const scriptSource = `'<script lang="ts">',
-'import Vue, { mounted } from "vue";',
+'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
 '@Component',
 'export default class {}',
 '</script>',

--- a/src/__tests__/option.test.ts
+++ b/src/__tests__/option.test.ts
@@ -1,0 +1,29 @@
+import { OptionParser } from '../migrator/option';
+
+describe('OptionParser', () => {
+  describe('when options are not provided', () => {
+    it('should throw an error', () => {
+      expect(() => new OptionParser({}).parse()).toThrowError('Either directory or file should be provided. Not both or none');
+    });
+  });
+
+  describe('when both directory and file are provided', () => {
+    it('should throw an error', () => {
+      expect(() => new OptionParser({ directory: 'dir', file: 'file' }).parse()).toThrowError('Either directory or file should be provided. Not both or none');
+    });
+  });
+
+  describe('when directory is provided', () => {
+    it('should return directory mode option', () => {
+      const options = new OptionParser({ directory: '/home/auto-test', sfc: true }).parse();
+      expect(options).toStrictEqual({ directory: '/home/auto-test', sfc: true });
+    });
+  });
+
+  describe('when file is provided', () => {
+    it('should return file mode option', () => {
+      const options = new OptionParser({ file: '/home/auto-test/InputNumber.vue', sfc: false }).parse();
+      expect(options).toStrictEqual({ file: '/home/auto-test/InputNumber.vue', sfc: false });
+    });
+  });
+});

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,8 +1,14 @@
 import { randomBytes } from 'crypto';
-import { Project } from 'ts-morph';
+import { IndentationText, Project, QuoteKind } from 'ts-morph';
 import { migrateFile } from '../migrator';
 
-export const project = new Project({ useInMemoryFileSystem: true });
+export const project = new Project({
+  useInMemoryFileSystem: true,
+  manipulationSettings: {
+    quoteKind: QuoteKind.Single,
+    indentationText: IndentationText.TwoSpaces,
+  },
+});
 export const createSourceFile = (content = undefined as string | undefined, ext = 'ts') => {
   const randomString = randomBytes(5).toString('hex');
   return project.createSourceFile(`./${randomString}.${ext}`, content);

--- a/src/__tests__/vue-class-component/migrator-component-decorator.test.ts
+++ b/src/__tests__/vue-class-component/migrator-component-decorator.test.ts
@@ -10,7 +10,7 @@ describe('@Component decorator', () => {
       `@Component({})
             class Test {}
             `,
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             const Test = defineComponent({})
         `,
@@ -23,7 +23,7 @@ describe('@Component decorator', () => {
             class Test {}
             `,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             const Test = defineComponent({})
         `,
@@ -37,7 +37,7 @@ describe('@Component decorator', () => {
             })
             export default class Test {}`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 mixins: [A,B,C]
@@ -52,7 +52,7 @@ describe('@Component decorator', () => {
             })
             export default class Test extends AnotherClass {}`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 mixins: [A,B,C],
@@ -89,7 +89,7 @@ describe('@Component decorator', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             const beforeCreate = () => {};
             export default defineComponent({

--- a/src/__tests__/vue-class-component/migrator-component-decorator.test.ts
+++ b/src/__tests__/vue-class-component/migrator-component-decorator.test.ts
@@ -10,7 +10,7 @@ describe('@Component decorator', () => {
       `@Component({})
             class Test {}
             `,
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const Test = defineComponent({})
         `,
@@ -23,7 +23,7 @@ describe('@Component decorator', () => {
             class Test {}
             `,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const Test = defineComponent({})
         `,
@@ -37,7 +37,7 @@ describe('@Component decorator', () => {
             })
             export default class Test {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 mixins: [A,B,C]
@@ -52,7 +52,7 @@ describe('@Component decorator', () => {
             })
             export default class Test extends AnotherClass {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 mixins: [A,B,C],
@@ -89,7 +89,7 @@ describe('@Component decorator', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const beforeCreate = () => {};
             export default defineComponent({

--- a/src/__tests__/vue-class-component/migrator-data.test.ts
+++ b/src/__tests__/vue-class-component/migrator-data.test.ts
@@ -47,7 +47,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Result
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data: () => { return { a: 1 }; }
@@ -62,7 +62,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Result
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data() { return { a: 1 }; }
@@ -82,7 +82,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data() {
@@ -106,7 +106,7 @@ describe('Data Property Migration', () => {
                     };
                 }`,
         // Throws
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data() {
@@ -130,7 +130,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data() {
@@ -167,7 +167,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data() {
@@ -201,7 +201,7 @@ describe('Data Property Migration', () => {
                     myProp3 = false;
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data() {
@@ -239,7 +239,7 @@ describe('Data Property Migration', () => {
                     };
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     data() {

--- a/src/__tests__/vue-class-component/migrator-data.test.ts
+++ b/src/__tests__/vue-class-component/migrator-data.test.ts
@@ -47,7 +47,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data: () => { return { a: 1 }; }
@@ -62,7 +62,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() { return { a: 1 }; }
@@ -82,7 +82,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -106,7 +106,7 @@ describe('Data Property Migration', () => {
                     };
                 }`,
         // Throws
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -130,7 +130,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -167,7 +167,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -201,7 +201,7 @@ describe('Data Property Migration', () => {
                     myProp3 = false;
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -239,7 +239,7 @@ describe('Data Property Migration', () => {
                     };
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {

--- a/src/__tests__/vue-class-component/migrator-getter-setter.test.ts
+++ b/src/__tests__/vue-class-component/migrator-getter-setter.test.ts
@@ -15,7 +15,7 @@ describe('Data Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -38,7 +38,7 @@ describe('Data Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -66,7 +66,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-class-component/migrator-getter-setter.test.ts
+++ b/src/__tests__/vue-class-component/migrator-getter-setter.test.ts
@@ -15,7 +15,7 @@ describe('Data Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {
@@ -38,7 +38,7 @@ describe('Data Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     watch: {
@@ -66,7 +66,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-class-component/migrator-methods.test.ts
+++ b/src/__tests__/vue-class-component/migrator-methods.test.ts
@@ -15,7 +15,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     created() {
@@ -37,7 +37,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     created() {
@@ -61,7 +61,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {
@@ -84,7 +84,7 @@ describe('Methods Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     watch: {
@@ -112,7 +112,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-class-component/migrator-methods.test.ts
+++ b/src/__tests__/vue-class-component/migrator-methods.test.ts
@@ -15,7 +15,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     created() {
@@ -37,7 +37,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     created() {
@@ -61,7 +61,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -84,7 +84,7 @@ describe('Methods Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -112,7 +112,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-class-component/migrator-mixins.test.ts
+++ b/src/__tests__/vue-class-component/migrator-mixins.test.ts
@@ -10,7 +10,7 @@ describe('Component extends', () => {
       `@Component
             export default class Test extends AnotherTest {}`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 extends: AnotherTest
@@ -23,7 +23,7 @@ describe('Component extends', () => {
       `@Component
             export default class Test extends AnotherTest {}`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 extends: AnotherTest

--- a/src/__tests__/vue-class-component/migrator-mixins.test.ts
+++ b/src/__tests__/vue-class-component/migrator-mixins.test.ts
@@ -10,7 +10,7 @@ describe('Component extends', () => {
       `@Component
             export default class Test extends AnotherTest {}`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 extends: AnotherTest
@@ -23,7 +23,7 @@ describe('Component extends', () => {
       `@Component
             export default class Test extends AnotherTest {}`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 extends: AnotherTest

--- a/src/__tests__/vue-class-component/migrator-props.test.ts
+++ b/src/__tests__/vue-class-component/migrator-props.test.ts
@@ -17,7 +17,7 @@ describe('Component props', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             const props = {
                 test: 1
@@ -44,7 +44,7 @@ describe('Component props', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 props: {
@@ -67,7 +67,7 @@ describe('Component props', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 name: "test",

--- a/src/__tests__/vue-class-component/migrator-props.test.ts
+++ b/src/__tests__/vue-class-component/migrator-props.test.ts
@@ -17,7 +17,7 @@ describe('Component props', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const props = {
                 test: 1
@@ -44,7 +44,7 @@ describe('Component props', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 props: {
@@ -67,7 +67,7 @@ describe('Component props', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 name: "test",

--- a/src/__tests__/vue-class-component/watch.test.ts
+++ b/src/__tests__/vue-class-component/watch.test.ts
@@ -21,7 +21,7 @@ describe('Component watch', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 watch: {
@@ -45,7 +45,7 @@ describe('Component watch', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
             export default defineComponent({
                 name: "test",

--- a/src/__tests__/vue-class-component/watch.test.ts
+++ b/src/__tests__/vue-class-component/watch.test.ts
@@ -21,7 +21,7 @@ describe('Component watch', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 watch: {
@@ -45,7 +45,7 @@ describe('Component watch', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 name: "test",

--- a/src/__tests__/vue-property-decorator/model.test.ts
+++ b/src/__tests__/vue-property-decorator/model.test.ts
@@ -13,7 +13,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     model: {
@@ -37,7 +37,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     model: {
@@ -61,7 +61,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     model: {
@@ -85,7 +85,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     model: {

--- a/src/__tests__/vue-property-decorator/model.test.ts
+++ b/src/__tests__/vue-property-decorator/model.test.ts
@@ -13,7 +13,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {
@@ -37,7 +37,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {
@@ -61,7 +61,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {
@@ -85,7 +85,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {

--- a/src/__tests__/vue-property-decorator/modelSync.test.ts
+++ b/src/__tests__/vue-property-decorator/modelSync.test.ts
@@ -13,7 +13,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!
         }`,
       // Result
-      `import { defineComponent, PropType } from "vue";
+      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
   
         export default defineComponent({
           model: {
@@ -47,7 +47,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
   
         export default defineComponent({
           model: {
@@ -81,7 +81,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: MyCheckedValue
         }`,
       // Result
-      `import { defineComponent, PropType } from "vue";
+      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
   
         export default defineComponent({
           model: {
@@ -115,7 +115,7 @@ describe('@ModelSync decorator', () => {
         readonly checkedValue!: boolean
       }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
         export default defineComponent({
           model: {
@@ -149,7 +149,7 @@ describe('@ModelSync decorator', () => {
             readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
         export default defineComponent({
           model: {
@@ -183,7 +183,7 @@ describe('@ModelSync decorator', () => {
             readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
         export default defineComponent({
             model: {

--- a/src/__tests__/vue-property-decorator/modelSync.test.ts
+++ b/src/__tests__/vue-property-decorator/modelSync.test.ts
@@ -13,7 +13,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!
         }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -81,7 +81,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: MyCheckedValue
         }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {

--- a/src/__tests__/vue-property-decorator/modelSync.test.ts
+++ b/src/__tests__/vue-property-decorator/modelSync.test.ts
@@ -13,7 +13,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!
         }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -47,7 +47,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -81,7 +81,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: MyCheckedValue
         }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -115,7 +115,7 @@ describe('@ModelSync decorator', () => {
         readonly checkedValue!: boolean
       }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
         export default defineComponent({
           model: {
@@ -149,7 +149,7 @@ describe('@ModelSync decorator', () => {
             readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
         export default defineComponent({
           model: {
@@ -183,7 +183,7 @@ describe('@ModelSync decorator', () => {
             readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
         export default defineComponent({
             model: {

--- a/src/__tests__/vue-property-decorator/propSync.test.ts
+++ b/src/__tests__/vue-property-decorator/propSync.test.ts
@@ -13,7 +13,7 @@ describe('@PropSync decorator', () => {
             syncedName;
         }`,
       // Result
-      `import { defineComponent, PropType } from "vue";
+      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
     
         export default defineComponent({
             props: {
@@ -43,7 +43,7 @@ describe('@PropSync decorator', () => {
                         syncedName: string;
                     }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
     
                     export default defineComponent({
                         props: {
@@ -73,7 +73,7 @@ describe('@PropSync decorator', () => {
                       syncedName: string | boolean;
                   }`,
       // Result
-      `import { defineComponent, PropType } from "vue";
+      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
   
                   export default defineComponent({
                       props: {
@@ -103,7 +103,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {
@@ -133,7 +133,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {
@@ -163,7 +163,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {

--- a/src/__tests__/vue-property-decorator/propSync.test.ts
+++ b/src/__tests__/vue-property-decorator/propSync.test.ts
@@ -13,7 +13,7 @@ describe('@PropSync decorator', () => {
             syncedName;
         }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
     
         export default defineComponent({
             props: {
@@ -73,7 +73,7 @@ describe('@PropSync decorator', () => {
                       syncedName: string | boolean;
                   }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
   
                   export default defineComponent({
                       props: {

--- a/src/__tests__/vue-property-decorator/propSync.test.ts
+++ b/src/__tests__/vue-property-decorator/propSync.test.ts
@@ -13,7 +13,7 @@ describe('@PropSync decorator', () => {
             syncedName;
         }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
     
         export default defineComponent({
             props: {
@@ -43,7 +43,7 @@ describe('@PropSync decorator', () => {
                         syncedName: string;
                     }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                     export default defineComponent({
                         props: {
@@ -73,7 +73,7 @@ describe('@PropSync decorator', () => {
                       syncedName: string | boolean;
                   }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
   
                   export default defineComponent({
                       props: {
@@ -103,7 +103,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -133,7 +133,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -163,7 +163,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {

--- a/src/__tests__/vue-property-decorator/props.test.ts
+++ b/src/__tests__/vue-property-decorator/props.test.ts
@@ -14,7 +14,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from "vue";
+      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {
@@ -43,7 +43,7 @@ describe('@Prop decorator', () => {
                       permissions!: CommentPermissions;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {
@@ -78,7 +78,7 @@ describe('@Prop decorator', () => {
                     checkId: string;            
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
     
                 export default defineComponent({
                     props: {
@@ -104,7 +104,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from "vue";
+      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
     
                 export default defineComponent({
                     props: {
@@ -124,7 +124,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Result
-      `import { defineComponent, PropType } from "vue";
+      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {
@@ -147,7 +147,7 @@ describe('@Prop decorator', () => {
                   @Prop([String, Boolean]) readonly propC: string | boolean | undefined
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {
@@ -173,7 +173,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     props: {
@@ -191,7 +191,7 @@ describe('@Prop decorator', () => {
                     checkId: string;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
     
                 export default defineComponent({
                     props: {
@@ -209,7 +209,7 @@ describe('@Prop decorator', () => {
                     checkId;
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
     
                 export default defineComponent({
                     props: {

--- a/src/__tests__/vue-property-decorator/props.test.ts
+++ b/src/__tests__/vue-property-decorator/props.test.ts
@@ -14,7 +14,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -104,7 +104,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -124,7 +124,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {

--- a/src/__tests__/vue-property-decorator/props.test.ts
+++ b/src/__tests__/vue-property-decorator/props.test.ts
@@ -14,7 +14,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -43,7 +43,7 @@ describe('@Prop decorator', () => {
                       permissions!: CommentPermissions;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -78,7 +78,7 @@ describe('@Prop decorator', () => {
                     checkId: string;            
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -104,7 +104,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -124,7 +124,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -147,7 +147,7 @@ describe('@Prop decorator', () => {
                   @Prop([String, Boolean]) readonly propC: string | boolean | undefined
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -173,7 +173,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -191,7 +191,7 @@ describe('@Prop decorator', () => {
                     checkId: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -209,7 +209,7 @@ describe('@Prop decorator', () => {
                     checkId;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {

--- a/src/__tests__/vue-property-decorator/refs.test.ts
+++ b/src/__tests__/vue-property-decorator/refs.test.ts
@@ -13,7 +13,7 @@ describe('@Ref', () => {
                     @Ref() readonly anotherComponent!: AnotherComponent
                 }`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -36,7 +36,7 @@ describe('@Ref', () => {
                     readonly defaultInput!: HTMLInputElement;                  
                 }`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -59,7 +59,7 @@ describe('@Ref', () => {
                     readonly defaultInput!: HTMLInputElement;                  
                 }`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-property-decorator/refs.test.ts
+++ b/src/__tests__/vue-property-decorator/refs.test.ts
@@ -13,7 +13,7 @@ describe('@Ref', () => {
                     @Ref() readonly anotherComponent!: AnotherComponent
                 }`,
         // Result
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {
@@ -36,7 +36,7 @@ describe('@Ref', () => {
                     readonly defaultInput!: HTMLInputElement;                  
                 }`,
         // Result
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {
@@ -59,7 +59,7 @@ describe('@Ref', () => {
                     readonly defaultInput!: HTMLInputElement;                  
                 }`,
         // Result
-        `import { defineComponent } from "vue";
+        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-property-decorator/watch.test.ts
+++ b/src/__tests__/vue-property-decorator/watch.test.ts
@@ -13,7 +13,7 @@ describe('@Watch decorator', () => {
                     onChildChanged(val: string) { console.log("onChildChanged"); }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -40,7 +40,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -68,7 +68,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -99,7 +99,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {

--- a/src/__tests__/vue-property-decorator/watch.test.ts
+++ b/src/__tests__/vue-property-decorator/watch.test.ts
@@ -13,7 +13,7 @@ describe('@Watch decorator', () => {
                     onChildChanged(val: string) { console.log("onChildChanged"); }
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     watch: {
@@ -40,7 +40,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     watch: {
@@ -68,7 +68,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     watch: {
@@ -99,7 +99,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     watch: {

--- a/src/__tests__/vuex/action.test.ts
+++ b/src/__tests__/vuex/action.test.ts
@@ -13,7 +13,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -33,7 +33,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -53,7 +53,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -73,7 +73,7 @@ describe('Vuex @Action', () => {
                     reload: (p1: string, p2, p3: number) => number;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {

--- a/src/__tests__/vuex/action.test.ts
+++ b/src/__tests__/vuex/action.test.ts
@@ -13,7 +13,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {
@@ -33,7 +33,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {
@@ -53,7 +53,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {
@@ -73,7 +73,7 @@ describe('Vuex @Action', () => {
                     reload: (p1: string, p2, p3: number) => number;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {

--- a/src/__tests__/vuex/getter.test.ts
+++ b/src/__tests__/vuex/getter.test.ts
@@ -12,7 +12,7 @@ describe('Vuex @Getter', () => {
                     @Getter bar: string | null;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {
@@ -32,7 +32,7 @@ describe('Vuex @Getter', () => {
                     getItemById!;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {
@@ -52,7 +52,7 @@ describe('Vuex @Getter', () => {
                     getItemById!;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vuex/getter.test.ts
+++ b/src/__tests__/vuex/getter.test.ts
@@ -12,7 +12,7 @@ describe('Vuex @Getter', () => {
                     @Getter bar: string | null;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -32,7 +32,7 @@ describe('Vuex @Getter', () => {
                     getItemById!;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -52,7 +52,7 @@ describe('Vuex @Getter', () => {
                     getItemById!;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vuex/mutation.test.ts
+++ b/src/__tests__/vuex/mutation.test.ts
@@ -13,7 +13,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -33,7 +33,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -53,7 +53,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -73,7 +73,7 @@ describe('Vuex @Mutation', () => {
                     reload: (p1: string, p2, p3: number) => number;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {

--- a/src/__tests__/vuex/mutation.test.ts
+++ b/src/__tests__/vuex/mutation.test.ts
@@ -13,7 +13,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {
@@ -33,7 +33,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {
@@ -53,7 +53,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {
@@ -73,7 +73,7 @@ describe('Vuex @Mutation', () => {
                     reload: (p1: string, p2, p3: number) => number;
                 }`,
       // Results
-      `import { defineComponent } from "vue";
+      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
 
                 export default defineComponent({
                     methods: {

--- a/src/migrator-cli.ts
+++ b/src/migrator-cli.ts
@@ -1,14 +1,15 @@
 import { Command } from 'commander';
-import { migrateDirectory } from './migrator';
+import { migrate } from './migrator';
 
 const program = new Command()
-  .requiredOption('-d, --directory <string>', 'Directory to migrate')
+  .option('-d, --directory <string>', 'Directory to migrate. Either directory or file should be provided, not both or none.')
+  .option('-f, --file <string>', 'Directory to migrate, Either directory or file should be provided, not both or none.')
   .option(
     '-s, --sfc',
     'If you would like to generate a SFC and remove the original scss and ts files',
     false,
   )
-  .action((options) => migrateDirectory(options.directory, options.sfc))
+  .action((options) => migrate(options))
   .parse(process.argv);
 
 export default program;

--- a/src/migrator/index.ts
+++ b/src/migrator/index.ts
@@ -1,4 +1,6 @@
 export {
   migrateDirectory,
   migrateFile,
+  migrate,
+  migrateSingleFile,
 } from './migrator';

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import {
+  IndentationText,
   Project,
+  QuoteKind,
   SourceFile,
 } from 'ts-morph';
 import logger from './logger';
@@ -91,9 +93,16 @@ const migrateEachFile = (
   return filesToMigrate.map((sourceFile) => resolveFileMigration(sourceFile, project));
 };
 
+const createProject = () => new Project({
+  manipulationSettings: {
+    quoteKind: QuoteKind.Single,
+    indentationText: IndentationText.TwoSpaces,
+  },
+});
+
 export const migrateDirectory = async (directoryPath: string, toSFC: boolean) => {
   const directoryToMigrate = path.join(process.cwd(), directoryPath);
-  const project = new Project({});
+  const project = createProject();
 
   project.addSourceFilesAtPaths(`${directoryToMigrate}/**/*.(ts|vue|scss)`)
     .filter((sourceFile) => !['.vue', '.ts'].includes(sourceFile.getExtension())
@@ -140,7 +149,7 @@ export const migrateSingleFile = async (filePath: string, toSFC: boolean): Promi
   }
 
   const fileToMigrate = path.join(process.cwd(), filePath);
-  const project = new Project({});
+  const project = createProject();
   project.addSourceFileAtPath(fileToMigrate);
   const sourceFiles = project.getSourceFiles();
 

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -6,8 +6,18 @@ import {
   SourceFile,
 } from 'ts-morph';
 import logger from './logger';
-import migrateVueClassComponent from './vue-class-component';
-import migrateVueClassProperties from './vue-property-decorator';
+import migrateProps from './vue-property-decorator/prop';
+import migratePropSyncs from './vue-property-decorator/propSync';
+import migrateModels from './vue-property-decorator/model';
+import migrateModelSyncs from './vue-property-decorator/modelSync';
+import migrateRefs from './vue-property-decorator/ref';
+import migrateWatchers from './vue-property-decorator/watch';
+import migrateData from './vue-class-component/migrate-data';
+import migrateExtends from './vue-class-component/migrate-extends';
+import migrateGetters from './vue-class-component/migrate-getters';
+import migrateImports from './vue-class-component/migrate-imports';
+import migrateMethods from './vue-class-component/migrate-methods';
+import migrateSetters from './vue-class-component/migrate-setters';
 import migrateVuexDecorators from './vuex';
 import { getScriptContent, injectScript, vueFileToSFC } from './migrator-to-sfc';
 import { createMigrationManager } from './migratorManager';
@@ -24,8 +34,18 @@ const migrateTsFile = async (project: Project, sourceFile: SourceFile): Promise<
   try {
     const migrationManager = createMigrationManager(sourceFile, outFile);
 
-    migrateVueClassComponent(migrationManager);
-    migrateVueClassProperties(migrationManager);
+    migrateImports(migrationManager.outFile);
+    migrateExtends(migrationManager.clazz, migrationManager.mainObject);
+    migrateProps(migrationManager);
+    migratePropSyncs(migrationManager);
+    migrateData(migrationManager.clazz, migrationManager.mainObject);
+    migrateGetters(migrationManager);
+    migrateSetters(migrationManager.clazz, migrationManager.mainObject);
+    migrateWatchers(migrationManager);
+    migrateMethods(migrationManager.clazz, migrationManager.mainObject);
+    migrateModels(migrationManager);
+    migrateModelSyncs(migrationManager);
+    migrateRefs(migrationManager);
     migrateVuexDecorators(migrationManager);
   } catch (error) {
     await outFile.deleteImmediately();

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -9,6 +9,9 @@ import migrateVueClassProperties from './vue-property-decorator';
 import migrateVuexDecorators from './vuex';
 import { getScriptContent, injectScript, vueFileToSFC } from './migrator-to-sfc';
 import { createMigrationManager } from './migratorManager';
+import {
+  canBeCliOptions, DirectoryModeOption, FileModeOption, OptionParser,
+} from './option';
 
 const migrateTsFile = async (project: Project, sourceFile: SourceFile): Promise<SourceFile> => {
   const filePath = sourceFile.getFilePath();
@@ -52,7 +55,10 @@ const migrateVueFile = async (project: Project, vueSourceFile: SourceFile) => {
   }
 };
 
-export const migrateFile = async (project: Project, sourceFile: SourceFile) => {
+export const migrateFile = async (
+  project: Project,
+  sourceFile: SourceFile,
+): Promise<SourceFile> => {
   logger.info(`Migrating ${sourceFile.getBaseName()}`);
   if (!sourceFile.getText().includes('@Component')) {
     throw new Error('File already migrated');
@@ -69,6 +75,20 @@ export const migrateFile = async (project: Project, sourceFile: SourceFile) => {
   }
 
   throw new Error(`Extension ${ext} not supported`);
+};
+
+const migrateEachFile = (
+  filesToMigrate: SourceFile[],
+  project: Project,
+): Promise<SourceFile>[] => {
+  const resolveFileMigration = (s: SourceFile, p: Project) => migrateFile(p, s)
+    .catch((err) => {
+      logger.error(`Error migrating ${s.getFilePath()}`);
+      logger.error(err);
+      return Promise.reject(err);
+    });
+
+  return filesToMigrate.map((sourceFile) => resolveFileMigration(sourceFile, project));
 };
 
 export const migrateDirectory = async (directoryPath: string, toSFC: boolean) => {
@@ -92,13 +112,7 @@ export const migrateDirectory = async (directoryPath: string, toSFC: boolean) =>
     `Migrating directory: ${directoryToMigrate}, ${finalFilesToMigrate.length} Files needs migration`,
   );
 
-  const migrationPromises = finalFilesToMigrate
-    .map((sourceFile) => migrateFile(project, sourceFile)
-      .catch((err) => {
-        logger.error(`Error migrating ${sourceFile.getFilePath()}`);
-        logger.error(err);
-        return Promise.reject(err);
-      }));
+  const migrationPromises = migrateEachFile(finalFilesToMigrate, project);
 
   try {
     await Promise.all(migrationPromises);
@@ -115,5 +129,49 @@ export const migrateDirectory = async (directoryPath: string, toSFC: boolean) =>
 
     logger.info(`Migrating directory: ${directoryToMigrate}, files to SFC`);
     await Promise.all(vueFiles.map((f) => vueFileToSFC(project, f)));
+  }
+};
+
+export const migrateSingleFile = async (filePath: string, toSFC: boolean): Promise<void> => {
+  const fileExtensionPattern = /.+\.(vue|ts)$/;
+  if (!fileExtensionPattern.test(filePath)) {
+    logger.info(`${filePath} can not migrate. Only .vue files are supported.`);
+    return;
+  }
+
+  const fileToMigrate = path.join(process.cwd(), filePath);
+  const project = new Project({});
+  project.addSourceFileAtPath(fileToMigrate);
+  const sourceFiles = project.getSourceFiles();
+
+  logger.info(`Migrating file: ${fileToMigrate}`);
+
+  const migrationPromises = migrateEachFile(sourceFiles, project);
+  try {
+    await Promise.all(migrationPromises);
+  } catch (error) {
+    return;
+  }
+
+  if (toSFC) {
+    logger.info(`Migrating file: ${fileToMigrate}, files to SFC`);
+    await Promise.all(sourceFiles.map((f) => vueFileToSFC(project, f)));
+  }
+};
+
+/**
+ * Entry function to start migration
+ */
+export const migrate = async (option: any): Promise<void> => {
+  if (!canBeCliOptions(option)) {
+    throw new Error('Cli option should be provided. Run --help for more info');
+  }
+  const result = new OptionParser(option).parse();
+  if (Object.keys(result).includes('file')) {
+    const fileModeOption = result as FileModeOption;
+    migrateSingleFile(fileModeOption.file, (fileModeOption.sfc ?? false));
+  } else {
+    const directoryModeOption = result as DirectoryModeOption;
+    migrateDirectory(directoryModeOption.directory, (directoryModeOption.sfc ?? false));
   }
 };

--- a/src/migrator/migratorManager.ts
+++ b/src/migrator/migratorManager.ts
@@ -182,7 +182,7 @@ export default class MigrationManager {
       .getImportDeclaration((imp) => imp.getModuleSpecifierValue() === module);
     if (!importDeclaration?.getNamedImports()
       .some((imp) => imp.getText() === namedImport)) {
-      importDeclaration?.addNamedImport('PropType');
+      importDeclaration?.addNamedImport({ name: 'PropType', isTypeOnly: true });
     }
   }
 

--- a/src/migrator/migratorManager.ts
+++ b/src/migrator/migratorManager.ts
@@ -200,7 +200,7 @@ export default class MigrationManager {
     fallbackType = isFunction ? 'Function' : fallbackType;
 
     if (!propertyConstructorMapping[propertyType]) {
-      this.addNamedImport('vue', 'PropType');
+      this.addNamedImport('~/lib/helper/fallback-composition-api', 'PropType');
       return `${fallbackType} as PropType<${propertyType}>`;
     }
 

--- a/src/migrator/option.ts
+++ b/src/migrator/option.ts
@@ -1,0 +1,43 @@
+export type CliOptions = {
+  directory?: string;
+  file?: string;
+  sfc?: boolean;
+};
+
+export type DirectoryModeOption = {
+  directory: string;
+  sfc?: boolean;
+};
+
+export type FileModeOption = {
+  file: string;
+  sfc?: boolean;
+};
+
+export type OptionMode = DirectoryModeOption | FileModeOption;
+
+export function canBeCliOptions(obj: any): obj is CliOptions {
+  return obj && typeof obj === 'object' && (obj.directory || obj.file || obj.sfc);
+}
+
+export class OptionParser {
+  constructor(private options: CliOptions) {
+    if ((!options.directory && !options.file) || (options.directory && options.file)) {
+      throw new Error('Either directory or file should be provided. Not both or none');
+    }
+  }
+
+  parse(): OptionMode {
+    if (this.options.directory) {
+      return {
+        directory: this.options.directory,
+        sfc: this.options.sfc,
+      };
+    }
+
+    return {
+      file: this.options.file,
+      sfc: this.options.sfc,
+    } as FileModeOption;
+  }
+}

--- a/src/migrator/vue-class-component/migrate-imports.ts
+++ b/src/migrator/vue-class-component/migrate-imports.ts
@@ -2,16 +2,16 @@ import { SourceFile } from 'ts-morph';
 
 // Import handling
 export default (outFile: SourceFile) => {
-  const importStatementsToRemove = ['vue-property-decorator', 'vue-class-component', 'vuex-class'];
+  const importStatementsToRemove = ['vue-property-decorator', 'vue-class-component', 'vuex-class', 'nuxt-property-decorator'];
 
   const vueImport = outFile.getImportDeclaration(
-    (importDeclaration) => importDeclaration.getModuleSpecifierValue() === 'vue',
+    (importDeclaration) => importDeclaration.getModuleSpecifierValue() === '~/lib/helper/fallback-composition-api',
   );
 
   if (!vueImport) {
     outFile.addImportDeclaration({
       defaultImport: '{ defineComponent }',
-      moduleSpecifier: 'vue',
+      moduleSpecifier: '~/lib/helper/fallback-composition-api',
     });
   } else {
     vueImport.addNamedImport('defineComponent');

--- a/src/migrator/vue-class-component/migrate-methods.ts
+++ b/src/migrator/vue-class-component/migrate-methods.ts
@@ -1,12 +1,18 @@
-import { ClassDeclaration, ObjectLiteralExpression } from 'ts-morph';
+import { ClassDeclaration, MethodDeclaration, ObjectLiteralExpression } from 'ts-morph';
 import { getObjectProperty } from '../utils';
 import { vueSpecialMethods } from '../config';
 
-export default (clazz: ClassDeclaration, mainObject: ObjectLiteralExpression) => {
+/**
+ * Add Vue special methods to the main object
+ */
+function appendVueSpecialMethods(
+  classDeclaration: ClassDeclaration,
+  mainObject: ObjectLiteralExpression,
+): void {
   vueSpecialMethods
-    .filter((m) => clazz.getMethod(m))
+    .filter((m) => classDeclaration.getMethod(m))
     .forEach((m) => {
-      const method = clazz.getMethodOrThrow(m);
+      const method = classDeclaration.getMethodOrThrow(m);
       const typeNode = method.getReturnTypeNode()?.getText();
       mainObject.addMethod({
         name: method.getName(),
@@ -15,6 +21,32 @@ export default (clazz: ClassDeclaration, mainObject: ObjectLiteralExpression) =>
         statements: method.getBodyText(),
       });
     });
+}
+
+/**
+ * Append methods to main object except Vue special methods
+ */
+function appendMethods(methods: MethodDeclaration[], mainObject: ObjectLiteralExpression): void {
+  const methodsObject = getObjectProperty(mainObject, 'methods');
+
+  methods.forEach((method) => {
+    if (method.getDecorators().length) {
+      throw new Error(`The method ${method.getName()} has non supported decorators.`);
+    }
+
+    const typeNode = method.getReturnTypeNode()?.getText();
+    methodsObject.addMethod({
+      name: method.getName(),
+      parameters: method.getParameters().map((p) => p.getStructure()),
+      isAsync: method.isAsync(),
+      returnType: typeNode,
+      statements: method.getBodyText(),
+    });
+  });
+}
+
+export default (clazz: ClassDeclaration, mainObject: ObjectLiteralExpression) => {
+  appendVueSpecialMethods(clazz, mainObject);
 
   const methods = clazz
     .getMethods()
@@ -24,22 +56,9 @@ export default (clazz: ClassDeclaration, mainObject: ObjectLiteralExpression) =>
         && !m.getDecorator('Watch'),
     );
 
-  if (methods.length) {
-    const methodsObject = getObjectProperty(mainObject, 'methods');
-
-    methods.forEach((method) => {
-      if (method.getDecorators().length) {
-        throw new Error(`The method ${method.getName()} has non supported decorators.`);
-      }
-
-      const typeNode = method.getReturnTypeNode()?.getText();
-      methodsObject.addMethod({
-        name: method.getName(),
-        parameters: method.getParameters().map((p) => p.getStructure()),
-        isAsync: method.isAsync(),
-        returnType: typeNode,
-        statements: method.getBodyText(),
-      });
-    });
+  if (!methods.length) {
+    return;
   }
+
+  appendMethods(methods, mainObject);
 };


### PR DESCRIPTION
# Overview

Modify orders of appending methods to components.

It may can be this order:

- props
- data
- computed
- watch
- methods
- created, mounted and so on(Vue lifecycle hooks)


