### PR TITLE
DEN-4986 [Automatic PR] Add concurrency to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,14 @@
 name: CI
 
-on:
-  [push, pull_request]
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:  
+    steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
@@ -13,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Lint code
-        run: npm run lint      
+        run: npm run lint
       - name: Test code
         run: npm test
       - name: Build package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,14 @@ name: Publish to NPM
 on:
   release:
     types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 jobs:
   publish:
     runs-on: ubuntu-latest
-    steps:  
+    steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
@@ -15,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Lint code
-        run: npm run lint      
+        run: npm run lint
       - name: Test code
         run: npm test
       - name: Build package


### PR DESCRIPTION
This is an automatic PR that adds concurrency to GHA workflows. As an effect there will be at most one running job __in a concurrency group__ (a branch) at any time, default branch excluded.
Optimizations like these are good for making runners available for other jobs, and will be enforced soon.

If you don't agree with these changes leave a review and raise your concern, otherwise please __merge the PR__.
